### PR TITLE
Undo compress offline settings

### DIFF
--- a/polarexplorer/settings_staging.py
+++ b/polarexplorer/settings_staging.py
@@ -24,8 +24,6 @@ DATABASES = {
 }
 
 COMPRESS_ROOT = "/var/www/polarexplorer/polarexplorer/media/"
-COMPRESS_ENABLED = True
-COMPRESS_OFFLINE = True
 DEBUG = False
 TEMPLATE_DEBUG = DEBUG
 STAGING_ENV = True


### PR DESCRIPTION
I got confused -- compress-offline is required for the new s3 stuff,
not bluegreen deployment, which is what i'm migrating to right now.