### PR TITLE
INFRA-2636: Update ctlsettings for ALB Migration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -85,7 +85,7 @@ django-smtp-ssl==1.0
 cffi==1.16.0 # cryptography
 cryptography==41.0.6  # pyOpenSSL
 
-ctlsettings==0.2.0
+ctlsettings==0.3.0
 
 pbr==6.0.0
 PyYAML>=3.10.0 # MIT


### PR DESCRIPTION
Update ctlsettings to 0.3.0 which supports ALB migration